### PR TITLE
Drop Python 3.8 & Add Support for Python 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ htmlcov
 # distribution
 dist
 *.egg-info
+
+# virtual enviroment
+venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+  - '3.11'
   - '3.12'
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: python
 
 python:
-  - 2.7
-  - 3.6
-  - 3.7
-  - 3.8
+  - '3.12'
 
 env:
-  - DJANGO_VERSION="Django>=1.11,<2"
-  - DJANGO_VERSION="Django>=2.0,<3"
-  - DJANGO_VERSION="Django>=3.0,<4"
+  - DJANGO_VERSION="Django>=5.2,<6"
 
 install:
   - pip install pyquery
@@ -19,13 +14,5 @@ install:
 script: coverage run quicktest.py multi_email_field.tests
 
 after_success:
- - pip install coveralls
- - coveralls
-
-# We need to exclude old versions of Python for tests with Django >= 2
-matrix:
-    exclude:
-        - python: 2.7
-          env: DJANGO_VERSION="Django>=2.0,<3"
-        - python: 2.7
-          env: DJANGO_VERSION="Django>=3.0,<4"
+  - pip install coveralls
+  - coveralls

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ CHANGELOG
 0.7.0 (2025-04-25)
 ==================
 
-- Dropped support for Python 3.8 and added support for Python 3.12.
+- Dropped support for Python 3.8 and added support for Python 3.11, 3.12.
 - Add support for Django 5.2
 
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+0.7.0 (2025-04-25)
+==================
+
+- Dropped support for Python 3.8 and added support for Python 3.12.
+- Add support for Django 5.2
+
+
 0.6.2 (2020-07-23)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ It provides:
 COMPATIBILITY
 ==================
 
-* Python 3.12
+* Python 3.11, 3.12
 * Django 5.2
 
 ==================

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ It provides:
 COMPATIBILITY
 ==================
 
-* Python 2.7 and 3.5+
-* Django 1.8+, 2.0+ and 3.0+
+* Python 3.12
+* Django 5.2
 
 ==================
 INSTALL

--- a/multi_email_field/fields.py
+++ b/multi_email_field/fields.py
@@ -2,13 +2,6 @@ from django.db import models
 
 from multi_email_field.forms import MultiEmailField as MultiEmailFormField
 
-try:
-    from django.utils import six
-
-    string_types = six.string_types
-except ImportError:
-    string_types = str
-
 
 class MultiEmailField(models.Field):
     description = "A multi e-mail field stored as a multi-lines text"
@@ -30,7 +23,7 @@ class MultiEmailField(models.Field):
         return value.splitlines()
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             return value
         elif isinstance(value, list):
             return "\n".join(value)

--- a/multi_email_field/forms.py
+++ b/multi_email_field/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from multi_email_field.widgets import MultiEmailWidget
 

--- a/multi_email_field/tests/tests.py
+++ b/multi_email_field/tests/tests.py
@@ -114,13 +114,13 @@ class MultiEmailFormFieldTest(SimpleTestCase):
         f = MultiEmailFormField()
         # Empty values
         for val in ['', None]:
-            self.assertEquals([], f.to_python(val))
+            self.assertEqual([], f.to_python(val))
         # One line correct value
         val = '  foo@bar.com    '
-        self.assertEquals(['foo@bar.com'], f.to_python(val))
+        self.assertEqual(['foo@bar.com'], f.to_python(val))
         # Multi lines correct values (test of #0010614)
         val = 'foo@bar.com\nfoo2@bar2.com\r\nfoo3@bar3.com'
-        self.assertEquals(['foo@bar.com', 'foo2@bar2.com', 'foo3@bar3.com'],
+        self.assertEqual(['foo@bar.com', 'foo2@bar2.com', 'foo3@bar3.com'],
                           f.to_python(val))
 
     def test__validate(self):

--- a/multi_email_field/widgets.py
+++ b/multi_email_field/widgets.py
@@ -4,13 +4,6 @@ from django.core import validators
 
 MULTI_EMAIL_FIELD_EMPTY_VALUES = validators.EMPTY_VALUES + ('[]', )
 
-try:
-    from django.utils import six
-
-    string_types = six.string_types
-except ImportError:
-    string_types = str
-
 
 class MultiEmailWidget(Textarea):
     is_hidden = False
@@ -19,7 +12,7 @@ class MultiEmailWidget(Textarea):
         """ Prepare value before effectively render widget """
         if value in MULTI_EMAIL_FIELD_EMPTY_VALUES:
             return ""
-        elif isinstance(value, string_types):
+        elif isinstance(value, str):
             return value
         elif isinstance(value, list):
             return "\n".join(value)

--- a/quicktest.py
+++ b/quicktest.py
@@ -40,7 +40,7 @@ class QuickDjangoTest(object):
                     'PORT': '',
                 }
             },
-            MIDDLEWARE_CLASSES=(
+            MIDDLEWARE=(
                 'django.contrib.sessions.middleware.SessionMiddleware',
                 'django.middleware.common.CommonMiddleware',
                 'django.middleware.csrf.CsrfViewMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
-six
+asgiref==3.8.1
+coverage==7.8.0
+cssselect==1.3.0
+Django==5.2
+lxml==5.4.0
+pyquery==2.0.1
+sqlparse==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='django-multi-email-field',
-    version='0.6.2',
+    version='0.7.0',
     author='Florent Lebreton',
     author_email='florent.lebreton@makina-corpus.com',
     url='https://github.com/fle/django-multi-email-field',
@@ -24,15 +24,9 @@ setup(
         'Intended Audience :: Developers',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 5.2',
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Framework :: Django :: 5.2',
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
### Resolves #5 
### Changes
- Removed Python 3.8 support
- Add Python 3.12 support and updated Django to v5.2
- Removed `six` package usage